### PR TITLE
Documented `verbose-provider-boot` flag and linted markdown

### DIFF
--- a/content/en/docs/measuring/configuration.md
+++ b/content/en/docs/measuring/configuration.md
@@ -60,13 +60,13 @@ We will this only focus on the `measurement` key:
 - `idle-time-end` **[integer]**: Seconds to idle containers after measurement
 - `flow-process-runtime` **[integer]**: Max. duration in seconds for how long one flow should take. Timeout-Exception is thrown if exceeded.
 - `metric-providers`:
-  - `METRIC_PROVIDER_NAME`: Key specifies the Metric Provider. [Possible Metric Providers →]({{< relref "metric-providers-overview" >}})
-  - `METRIC_PROVIDER_NAME.resolution`: **[integer]** sampling resolution in ms
+  + `METRIC_PROVIDER_NAME`: Key specifies the Metric Provider. [Possible Metric Providers →]({{< relref "metric-providers-overview" >}})
+  + `METRIC_PROVIDER_NAME.resolution`: **[integer]** sampling resolution in ms
 
 Some metric providers have unique configuration params:
 
 - PsuEnergyXgboostSystemProvider
-  - Please look at the always current documentation here to understand what values to plug in here: [XGBoost SPECPower Model documentation](https://github.com/green-coding-berlin/spec-power-model)
+  + Please look at the always current documentation here to understand what values to plug in here: [XGBoost SPECPower Model documentation](https://github.com/green-coding-berlin/spec-power-model)
 
 Also note that some providers are deactivated by default, because they either need a
 additional configuration parameters, extra hardware or a specially configured system.
@@ -82,7 +82,7 @@ the framework behaves.
 
 - `email`: The email where to error mails and debug mails to
 - `no_emails`: If the framework should send emails at all (including error mails).
-  - If you have not SMTP configured you must set this to `False`
+  + If you have not SMTP configured you must set this to `False`
 
 ## Switches for runner.py
 
@@ -90,23 +90,23 @@ Apart from the `config.yml` some configuration is additionally possible when doi
 with the `runner.py`.
 
 - `--uri` The URI to get the usage_scenario.yml from.
-  - If given a URL starting with `http(s)` the tool will try to clone a remote repository to `/tmp/green-metrics-tool/repo`
-  - If given a local directory starting with `/`, this will be used instead.
+  + If given a URL starting with `http(s)` the tool will try to clone a remote repository to `/tmp/green-metrics-tool/repo`
+  + If given a local directory starting with `/`, this will be used instead.
 - `--name` A name which will be stored to the database to discern this run from others
 - `--no-file-cleanup` flag to not delete the metric provider data in `/tmp/green-metrics-tool`
 - `--debug` flag to activate steppable debug mode
-  - This allows you to enter the containers and debug them if necessary.
+  + This allows you to enter the containers and debug them if necessary.
 - `--allow-unsafe` flag to activate unsafe volume bindings, ports, and complex env vars
-  - Arbitrary volume bindings into the containers. They are still read-only though
-  - Portmappings to the host OS.
-    - See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **ports** option for details
-  - Non-Strict ENV vars mapped into container
-    - See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **environment** option for details
+  + Arbitrary volume bindings into the containers. They are still read-only though
+  + Portmappings to the host OS.
+    * See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **ports** option for details
+  + Non-Strict ENV vars mapped into container
+    * See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **environment** option for details
 - `--skip-unsafe` flag to skip unsafe volume bindings, ports and complex env vars
-  - This is typically done when reusing already present `compose.yml` files without the need to alter the file
+  + This is typically done when reusing already present `compose.yml` files without the need to alter the file
 - `--verbose-provider-boot` flag to boot metric providers gradually
-  - This will enable the user to see the impact of each metric provider more clearly
-  - `RAPL` metric providers will be prioritized to start first, if enabled
+  + This will enable the user to see the impact of each metric provider more clearly
+  + `RAPL` metric providers will be prioritized to start first, if enabled
 
 These options are not available when doing cron runs.
 

--- a/content/en/docs/measuring/configuration.md
+++ b/content/en/docs/measuring/configuration.md
@@ -60,20 +60,20 @@ We will this only focus on the `measurement` key:
 - `idle-time-end` **[integer]**: Seconds to idle containers after measurement
 - `flow-process-runtime` **[integer]**: Max. duration in seconds for how long one flow should take. Timeout-Exception is thrown if exceeded.
 - `metric-providers`:
-    + `METRIC_PROVIDER_NAME`: Key specifies the Metric Provider. [Possible Metric Providers →]({{< relref "metric-providers-overview" >}})
-    + `METRIC_PROVIDER_NAME.resolution`: **[integer]** sampling resolution in ms
+  - `METRIC_PROVIDER_NAME`: Key specifies the Metric Provider. [Possible Metric Providers →]({{< relref "metric-providers-overview" >}})
+  - `METRIC_PROVIDER_NAME.resolution`: **[integer]** sampling resolution in ms
 
 Some metric providers have unique configuration params:
+
 - PsuEnergyXgboostSystemProvider
-    + Please look at the always current documentation here to understand what values to plug in here: [XGBoost SPECPower Model documentation](https://github.com/green-coding-berlin/spec-power-model)
+  - Please look at the always current documentation here to understand what values to plug in here: [XGBoost SPECPower Model documentation](https://github.com/green-coding-berlin/spec-power-model)
 
 Also note that some providers are deactivated by default, because they either need a
 additional configuration parameters, extra hardware or a specially configured system.
 
-Once you have set them up you can uncomment the line. In this example for instance 
-the line `psu.energy.xgboost.system.provider.PsuEnergyXgboostSystemProvider` and all 
+Once you have set them up you can uncomment the line. In this example for instance
+the line `psu.energy.xgboost.system.provider.PsuEnergyXgboostSystemProvider` and all
 the lines directly below it.
-
 
 ### admin
 
@@ -81,39 +81,45 @@ The `admin` key provides no configuration for the measurements themselves, but r
 the framework behaves.
 
 - `email`: The email where to error mails and debug mails to
-- `no_emails`: If the framework should send emails at all (including error mails). 
-    + If you have not SMTP configured you must set this to `False`
+- `no_emails`: If the framework should send emails at all (including error mails).
+  - If you have not SMTP configured you must set this to `False`
 
 ## Switches for runner.py
 
 Apart from the `config.yml` some configuration is additionally possible when doing manual runs
 with the `runner.py`.
 
-
-- `--uri` The URI to get the usage_scenario.yml from. 
-    + If given a URL starting with `http(s)` the tool will try to clone a remote repository to `/tmp/green-metrics-tool/repo`
-    + If given a local directory starting with `/`, this will be used instead.
+- `--uri` The URI to get the usage_scenario.yml from.
+  - If given a URL starting with `http(s)` the tool will try to clone a remote repository to `/tmp/green-metrics-tool/repo`
+  - If given a local directory starting with `/`, this will be used instead.
 - `--name` A name which will be stored to the database to discern this run from others
 - `--no-file-cleanup` flag to not delete the metric provider data in `/tmp/green-metrics-tool`
 - `--debug` flag to activate steppable debug mode
-    + This allows you to enter the containers and debug them if necessary.
+  - This allows you to enter the containers and debug them if necessary.
 - `--allow-unsafe` flag to activate unsafe volume bindings, ports, and complex env vars
-    + Arbitrary volume bindings into the containers. They are still read-only though
-    + Portmappings to the host OS. 
-        * See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **ports** option for details
-    + Non-Strict ENV vars mapped into container
-        * See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **environment** option for details
+  - Arbitrary volume bindings into the containers. They are still read-only though
+  - Portmappings to the host OS.
+    - See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **ports** option for details
+  - Non-Strict ENV vars mapped into container
+    - See [usage_scenario.yml →]({{< relref "usage-scenario" >}}) **environment** option for details
 - `--skip-unsafe` flag to skip unsafe volume bindings, ports and complex env vars
-    + This is typically done when reusing already present `compose.yml` files without the need to alter the file
+  - This is typically done when reusing already present `compose.yml` files without the need to alter the file
+- `--verbose-provider-boot` flag to boot metric providers gradually
+  - This will enable the user to see the impact of each metric provider more clearly
+  - `RAPL` metric providers will be prioritized to start first, if enabled
 
 These options are not available when doing cron runs.
 
 ## Typical calls
+
 ### Local app
+
 ```console
 python3 runner.py --uri PATH_TO_MY_SAMPLE_APP_FOLDER --name MY_NAME`
 ```
+
 ### Github repository
+
 ```console
 python3 runner.py --uri https://github.com/MY_GITHUB_NAME/MY_REPO --name MY_NAME
 ```


### PR DESCRIPTION
Hugo is complaining when trying to start the server locally:
```
❯ hugo server
Start building sites … 
hugo v0.107.0-2221b5b30a285d01220a26a82305906ad3291880+extended linux/amd64 BuildDate=2022-11-24T13:59:45Z VendorInfo=gohugoio
Error: Error building site: "/home/mr-computer/Workspace/documentation/content/en/docs/api/overview.md:19:1": failed to extract shortcode: template for shortcode "alert" not found
Built in 7 ms
```

Error comes from a file not edited by this PR, and I found the issue referenced online but the solutions don't work.
Could just be an issue on my machine, but wanted to mention it anyways.