### PR TITLE
Document python dependencies install on update

### DIFF
--- a/content/en/docs/installation/updating.md
+++ b/content/en/docs/installation/updating.md
@@ -34,6 +34,13 @@ docker compose down -v # optional!!! This will rebuild the database
 docker compose up -d
 ```
 
+## Re-install dependencies if needed
+
+If python dependencies has been updated, e.g. `requirements.txt` has been
+changed, then they need to be installed.
+
+    sudo python3 -m pip install -r ~/green-metrics-tool/requirements.txt
+
 ## Re-Run the install script
 
 After every new `git pull` you should run the `install.sh` script to get the newest binaries and configuration params for 


### PR DESCRIPTION
When trying to jump from mainline into development branches, I got into a missing dependency problem that happen over the 28d656a..5eca286 interval.
Namely `schema` was added.

    index ad7aca0..dc1e719 100644
    --- requirements.txt
    +++ requirements.txt
    @@ -1,4 +1,5 @@
     PyYAML==6.0
    -pandas==2.0.1
    +pandas==2.0.2
     psycopg[binary]==3.1.9
     pyserial==3.5
    +schema==0.7.5
    \ No newline at end of file

Here a change adding an step to install python dependencies on update if needed.