### PR TITLE
Added MCP39F511N incl. tech-specs update for RAPL and cluster

### DIFF
--- a/content/en/docs/measuring/measurement-cluster.md
+++ b/content/en/docs/measuring/measurement-cluster.md
@@ -25,7 +25,8 @@ We have the following machines available for running measurements in our cluster
     + Turbo Boost: Off
     + Memory: 16 GB
     + [Sample measurement with machine specs](https://metrics.green-coding.berlin/stats.html?id=9d250a5f-1f01-42a2-926e-e3f9b216ed5a)
-    + Metrics Provider for Machine Power: [PowerSpy2]({{< relref "metric-providers/psu-energy-ac-powerspy2" >}})
+    + Metrics Provider for Machine Power: [MCP39F511N]({{< relref "metric-providers/psu-energy-ac-mcp-machine" >}})
+    
 - **Fujitsu TX1330 M2**
     + Ubuntu 22.04 ([NOP Linux](https://www.green-coding.berlin/blog/nop-linux/))
     + Single-Tenant Server 
@@ -36,7 +37,8 @@ We have the following machines available for running measurements in our cluster
     + Turbo Boost: Off
     + Memory: 8 GB 
     + [Sample measurement with machine specs](https://metrics.green-coding.berlin/stats.html?id=9784422b-f4c6-42f3-addd-9e4c0833da74)
-    + Metrics Provider for Machine Power: [PowerSpy2]({{< relref "metric-providers/psu-energy-ac-powerspy2" >}})
+    + Metrics Provider for Machine Power: [MCP39F511N]({{< relref "metric-providers/psu-energy-ac-mcp-machine" >}})
+    
 - **Fujitsu TX1330 M3**
     + Ubuntu 22.04 ([NOP Linux](https://www.green-coding.berlin/blog/nop-linux/))
     + Single-Tenant Server 
@@ -47,7 +49,8 @@ We have the following machines available for running measurements in our cluster
     + Turbo Boost: Off
     + Memory: 16 GB
     + [Sample measurement with machine specs](https://metrics.green-coding.berlin/stats.html?id=8a30b1bd-8c54-4c9d-919e-fd7c291b900c)
-    + Metrics Provider for Machine Power: [PowerSpy2]({{< relref "metric-providers/psu-energy-ac-powerspy2" >}}) & [IPMI]({{< relref "metric-providers/psu-energy-ac-ipmi-machine" >}})
+    + Metrics Provider for Machine Power: [MCP39F511N]({{< relref "metric-providers/psu-energy-ac-mcp-machine" >}})
+    
 - **Fujitsu TX1330 M3**
     + Ubuntu 22.04 (default)
     + Single-Tenant Server 
@@ -57,8 +60,9 @@ We have the following machines available for running measurements in our cluster
     + Hyper-Threading: Off
     + Turbo Boost: Off
     + Memory: 16 GB
-    + Metrics Provider for Machine Power: [PowerSpy2]({{< relref "metric-providers/psu-energy-ac-powerspy2" >}}) & [IPMI]({{< relref "metric-providers/psu-energy-ac-ipmi-machine" >}})
-- **Quanta Leopard-DDR3**
+    + Metrics Provider for Machine Power: [MCP39F511N]({{< relref "metric-providers/psu-energy-ac-mcp-machine" >}}) & [IPMI]({{< relref "metric-providers/psu-energy-ac-ipmi-machine" >}})
+    
+- **Quanta Leopard-DDR3 - Currently unavailable**
     + 48-Thread Multi-Tenant Server 
     + Ubuntu 22.04 (default)
     + SoftAWERE compatible 

--- a/content/en/docs/measuring/metric-providers/cpu-energy-RAPL-MSR-system.md
+++ b/content/en/docs/measuring/metric-providers/cpu-energy-RAPL-MSR-system.md
@@ -12,13 +12,17 @@ This metric provider reads the energy of the CPU Package from the Running Averag
 
 This MSR keeps a running count of the energy used in a specified domain in microJoules. This metric provider specifically reads from the `energy-pkg` domain, which gives you the energy used by all the domains.
 
+### Technical specs
+
+- Time resolution: 976 micro-seconds
+- Energy resolution: 15.3 micro-Joules
+
 ### Classname
 - CpuEnergyRaplMsrSystemProvider
 
 ### Input Parameters
 - Args:
     - i: specifies interval in milliseconds between measurements
-        - from RAPL documentation: RAPL can only measure until 1ms resolution 
 
 ```
 > ./metric-provider-binary -i 100

--- a/content/en/docs/measuring/metric-providers/memory-energy-RAPL-MSR-system.md
+++ b/content/en/docs/measuring/metric-providers/memory-energy-RAPL-MSR-system.md
@@ -12,13 +12,17 @@ This metric provider reads the DRAM energy from the Running Average Power Limit 
 
 This MSR keeps a running count of the energy used in a specified domain in microJoules. This metric provider specifically reads from the `energy-pkg` domain, which gives you the energy used by all the domains.
 
+### Technical specs
+
+- Time resolution: 976 micro-seconds
+- Energy resolution: 15.3 micro-Joules
+
 ### Classname
 - MemoryEnergyRaplMsrSystemProvider
 
 ### Input Parameters
 - Args:
     - i: specifies interval in milliseconds between measurements
-        - from RAPL documentation: RAPL can only measure until 1ms resolution 
     - d: Must be set to activate the DRAM reading mode.
 
 ```

--- a/content/en/docs/measuring/metric-providers/psu-energy-ac-ipmi-machine.md
+++ b/content/en/docs/measuring/metric-providers/psu-energy-ac-ipmi-machine.md
@@ -13,6 +13,12 @@ This metric provider uses the [IPMI protocol](https://en.wikipedia.org/wiki/Inte
 draw of the system. 
 This can either come from a sensor that is accessible via `ACPI` or via other means through the `libsensors`.
 
+### Technical specs
+
+Most IPMI sensors do not supply data more often than once per second. Polling them more often is advised to catch 
+the transition of the value, but if the value is averaged internally over 1 second or if it just a single measurement
+depends on the BMC / ILO / iDRAC that IPMI is querying.
+
 ### Install
 
 You will need  `sudo apt-get install freeipmi-tools ipmitool` installed on a Debian based distro. 

--- a/content/en/docs/measuring/metric-providers/psu-energy-ac-mcp-machine.md
+++ b/content/en/docs/measuring/metric-providers/psu-energy-ac-mcp-machine.md
@@ -1,0 +1,58 @@
+---
+title: "PSU Energy - AC - MCP (MCP39F511N)"
+description: "Documentation for PsuEnergyAcMcpMachineProvider of the Green Metrics Tool"
+lead: ""
+date: 2023-10-20T08:16:35+0000
+draft: false
+images: []
+weight: 172
+---
+
+
+### What it does
+
+This metric provider uses the [MCP39F511N chip](https://www.microchip.com/en-us/product/mcp39f511n) to read the power used by a device plugged into it. Normally this would be the device we are benchmarking.
+
+We use the board implementation here: [AMD00706](https://www.microchip.com/en-us/development-tool/ADM00706)
+
+**Spec highlights:**
+- 0,5% Accuracy on active power measurements in a 1:4000 dynamic range (~ 3.75 mW minimum resolution)
+- 8 MHz internal processing clock (theoretical maximum of 12.5 us resolution)
+- Internal accumulation of energy in register (currently not active in our setup. We use active power only atm.)
+
+
+Implementation of the source code is mostly copied from https://github.com/osmhpi/pinpoint/blob/master/src/data_sources/mcp_com.c
+Credits to Sven Köhler and the OSM group from the HPI
+
+### Install
+
+All compilations and linking will be done through the install script.
+
+After that just plug it into your USB and please use Channel 1.
+
+### Classname
+
+- PsuEnergyAcMcpMachineProvider
+
+### Input Parameters
+
+- `-i`: interval in milliseconds. By default the measurement interval is 100 ms.
+
+
+```bash
+> ./metric-provider-binary -i 100
+```
+
+### Output
+
+This metric provider prints to stdout a continuous stream of data every `interval` milliseconds till it is stopped with
+`sigkill` or `sigint` (Ctrl-c). The format of the data is as follows:
+
+`TIMESTAMP READING`
+
+Where:
+- `TIMESTAMP`: Unix timestamp, in microseconds
+- `READING`: The value taken from sensor in the unit supplied or mW if no unit is specified.
+
+Any errors are printed to stderr.
+


### PR DESCRIPTION
- Time and energy resolution for RAPL added (976 micro-seconds / 15.3 micro-Joules)
- MCP39F511N energy measurement device doc added
- Updated cluster doc to replace PowerSpy as default with MCP39F511N