### PR TITLE
Add instructions on how to install GMT on Windows with WSL

### DIFF
--- a/content/en/docs/installation/installation-cluster.md
+++ b/content/en/docs/installation/installation-cluster.md
@@ -3,7 +3,7 @@ title: "Installation of a Cluster"
 description: "A description on how to run the GMT in a cluster with NOP Linux"
 lead: ""
 date: 2023-06-26T01:49:15+00:00
-weight: 903
+weight: 904
 ---
 
 ## Cluster setup

--- a/content/en/docs/installation/installation-linux.md
+++ b/content/en/docs/installation/installation-linux.md
@@ -18,7 +18,7 @@ The following distributions have been tested, but require manual work:
 - Ubuntu 20.04 (works, but *libglib* has to be manually updated to *libglib2.0-dev*)
 - Ubuntu 22.10 (works for development, but [cluster installation]({{< relref "installation-cluster" >}}) has different names for timers)
 
-{{< alert icon="💡" text="If you want to develop on macOS please use this installation description: <a href='/docs/installation/installation-mac/'>Installation on Mac</a>" />}}
+{{< alert icon="💡" text="If you want to develop on macOS or Windows please use the appropriate installation description: <ul><li><a href='/docs/installation/installation-mac/'>Installation on Mac</a></li><li><a href='/docs/installation/installation-windows/'>Installation on Windows (WSL)</a></li></ul>" />}}
 
 ## Downloading and installing required packages
 
@@ -196,7 +196,7 @@ is running on port `80` or `443`
 - Build the binaries for the Metric Providers
 - Set needed `/etc/sudoers` entry for requesting kernel scheduler info
 
-Please not that whenever you run the Green Metrics Tool you have to first activte the python `venv`.
+Please note that whenever you run the Green Metrics Tool you have to first activate the python `venv`.
 
 What you might want to add:
 

--- a/content/en/docs/installation/installation-macos.md
+++ b/content/en/docs/installation/installation-macos.md
@@ -43,7 +43,7 @@ is running on port `80` or `443`
 - Create the needed `/etc/hosts` entries for development
 - Set needed `/etc/sudoers` entry for running/ killing the `powermetrics` tool
 
-Please not that whenever you run the Green Metrics Tool you have to first activte the python `venv`!
+Please note that whenever you run the Green Metrics Tool you have to first activate the python `venv`!
 
 After that you can start the containers:
 

--- a/content/en/docs/installation/installation-windows.md
+++ b/content/en/docs/installation/installation-windows.md
@@ -1,0 +1,55 @@
+---
+title: "Installation on Windows"
+description: "A description on how to install the GMT on Windows machines"
+lead: ""
+date: 2023-12-04T01:49:15+00:00
+weight: 903
+---
+
+{{< alert icon="⚠" text="Running the GMT on Windows with WSL is only meant for development and testing of usage scenarios! It is not possible to use this setup for actual measurements!" />}}
+
+GMT can only run on Windows with the [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/) (WSL). Before installing GMT make sure you have a working WSL environment.
+
+With WSL you are working with a real Linux distribution (e.g. Ubuntu). Therefore, the most installation steps are equal to the ones documented in [Installation on Linux →]({{< relref "installation-linux#downloading-and-installing-required-packages" >}}). On this page we only document the things that are different.
+
+If you ever get stuck during this installation, be sure to reboot WSL once. It may help to correctly load some configurations and/or daemons.
+
+## Docker Desktop for Windows
+
+Docker provides a great installation help on their website: [https://docs.docker.com/desktop/install/windows-install/](https://docs.docker.com/desktop/install/windows-install/)
+
+You can just use the Docker Desktop for Windows bundle. Make sure the WSL 2 feature is enabled.
+
+## Setup
+
+Before following the setup instructions given in [Installation on Linux →]({{< relref "installation-linux#setup" >}}), make sure the automatic generation of the hosts file is disabled.
+
+### Disable automatic generation of hosts file
+
+```bash
+sudo vim /etc/wsl.conf
+```
+
+Add the following two lines:
+
+```bash
+[network]
+generateHosts = false
+```
+
+Reference: [https://devblogs.microsoft.com/commandline/automatically-configuring-wsl/](https://devblogs.microsoft.com/commandline/automatically-configuring-wsl/)
+
+### Add hosts entries to Windows
+
+To be able to access the frontend and the API of the GMT, you have to add the URLs to the hosts file on your Windows host system: `C:\Windows\System32\drivers\etc\hosts`
+
+```plain
+127.0.0.1 green-coding-postgres-container
+127.0.0.1 api.green-coding.internal metrics.green-coding.internal
+```
+
+### Metric providers
+
+With WSL it is not possible to measure anything except the CPU utilization via procfs (`cpu.utilization.procfs.system.provider`).
+
+You have to disable all other providers in your `config.yml`.

--- a/content/en/docs/installation/updating.md
+++ b/content/en/docs/installation/updating.md
@@ -3,7 +3,7 @@ title: "Updating"
 description: "Updating"
 lead: ""
 date: 2022-11-23T01:49:15+00:00
-weight: 904
+weight: 905
 ---
 
 The standard way of updating the Green Metrics Tool is to run:

--- a/content/en/docs/measuring/measuring-locally.md
+++ b/content/en/docs/measuring/measuring-locally.md
@@ -6,8 +6,8 @@ date: 2022-06-18T08:48:45+00:00
 weight: 820
 ---
 
-Before starting to measure you must first install some prerequisites.  
-See [Installation on Linux →]({{< relref "/docs/installation/installation-linux" >}}) or [Installation on macOS →]({{< relref "/docs/installation/installation-macos" >}})
+Before starting to measure you must first install some prerequisites.
+See [Installation on Linux →]({{< relref "/docs/installation/installation-linux" >}}), [Installation on macOS →]({{< relref "/docs/installation/installation-macos" >}}) or [Installation on Windows (WSL) →]({{< relref "/docs/installation/installation-windows" >}})
 
 Make sure your Docker containers are up and running.  
 If they are not, you can start them by running `docker compose up`  

--- a/content/en/docs/prologue/introduction.md
+++ b/content/en/docs/prologue/introduction.md
@@ -37,6 +37,7 @@ Refer to the installation instructions for your OS:
 
 - [Installation on Linux →]({{< relref "/docs/installation/installation-linux" >}})
 - [Installation on macOS →]({{< relref "/docs/installation/installation-macos" >}})
+- [Installation on Windows (WSL) →]({{< relref "/docs/installation/installation-windows" >}})
 
 Then proceed with [containerizing and measuring your applications →]({{< relref "/docs/measuring/containerizing-applications" >}}) to  
 understand how to prepare your app to be measured by the Green Metrics Tool.

--- a/content/en/docs/prologue/quick-start.md
+++ b/content/en/docs/prologue/quick-start.md
@@ -35,7 +35,7 @@ For the most basic setup you require:
 - `python3` including `pandas` and `pyyaml`
 - `docker` installed and preferably running in rootless-mode
 
-If you currently do not have these packages already available please refer to [Installation on Linux →]({{< relref "installation-linux" >}}) or [Installation on macOS →]({{< relref "installation-macos" >}})
+If you currently do not have these packages already available please refer to [Installation on Linux →]({{< relref "installation-linux" >}}), [Installation on macOS →]({{< relref "installation-macos" >}}) or [Installation on Windows (WSL) →]({{< relref "installation-windows" >}})
 
 If you already have that and want to skip the installation, please only add one entry to your `/etc/hosts`:
 


### PR DESCRIPTION
Currently, I'm developing and testing usage scenarios for GMT within the Windows Subsystem for Linux (WSL). Because there are some differences in installing GMT within WSL in comparison to a full Linux system, I think it makes sense to add them to the documentation.

My current setup:
- Windows 10 22H2 with WSL 2
- Ubuntu 22.04.3 LTS
- Docker Desktop 4.25.1 that uses the WSL 2 based engine
