### PR TITLE
cmd => command

### DIFF
--- a/content/en/docs/help/troubleshooting.md
+++ b/content/en/docs/help/troubleshooting.md
@@ -78,7 +78,7 @@ This is because a container has exited during the run of the GMT or you are runn
 - If not using rootless mode: Please turn all **cgroup** providers off, by commenting them out in the `config.yml`
 - If using rootless mode: Please keep the container alive by having a shell always open 
 
-A way to do this with the GMT directly without changing your containers would be the `cmd` command. See [usage_scenario.yml →]({{< relref "/docs/measuring/usage-scenario" >}}) 
+A way to do this with the GMT directly without changing your containers would be the `command` command. See [usage_scenario.yml →]({{< relref "/docs/measuring/usage-scenario" >}}) 
 
 An example where we use this command to keep a container alive is here: https://github.com/green-coding-berlin/example-applications/blob/main/idle/usage_scenario.yml
 

--- a/content/en/docs/measuring/containerizing-applications.md
+++ b/content/en/docs/measuring/containerizing-applications.md
@@ -19,7 +19,7 @@ When containerizing apps for the Green Metrics Tool,
 the containers *must not* shut down after starting them.
 
 So you either must have a daemon / process running inside the container  
-that keeps the container running or use the `cmd` option in the [usage_scenario.yml →]({{< relref "usage-scenario" >}})  
+that keeps the container running or use the `command` option in the [usage_scenario.yml →]({{< relref "usage-scenario" >}})  
 file to start a shell that keeps the container running.
 
 This is because our tool sends the commands to the containers after they have  

--- a/content/en/docs/measuring/usage-scenario.md
+++ b/content/en/docs/measuring/usage-scenario.md
@@ -94,8 +94,8 @@ services:
     - `folder-destination`: **[str]** *(optional)*
       + Specify where the project that is being measured will be mounted inside of the container
       + Defaults to `/tmp/repo`
-    - `cmd:` **[str]** *(optional)*
-      + Command to be executed when container is started. When container does not have a daemon running typically a shell is started here to have the container running like `bash` or `sh`
+    - `command:` **[str]** *(optional)*
+      + Command to be executed when container is started. When container does not have a daemon running typically a shell is started here to have the container running like `bash` or `sh`.
     - `shell:` **[str]** *(optional)*
       + Will execute the `setup-commands` in a shell. Use this if you need shell-mechanics like redirection `>` or chaining `&&`.
       + Please use a string for a shell command here like `sh`, `bash`, `ash` etc. The shell must be available in your container
@@ -156,7 +156,7 @@ flow:
     - `note:` **[str]** *(optional)*
       + A string that will appear as note attached to the datapoint of measurement (optional)
     - `ignore-errors:` **[bool]** *(optional)*
-      + If set to `true` the run will not fail if the process in `cmd` has a different exit code than `0`. Useful
+      + If set to `true` the run will not fail if the process in `command` has a different exit code than `0`. Useful
            if you execute a command that you know will always fail like `timeout 0.1 stress -c 1`
     - `shell:` **[str]** *(optional)*
       + Will execute the `command` in a shell. Use this if you need shell-mechanics like redirection `>` or chaining `&&`.

--- a/usage_scenario.yml
+++ b/usage_scenario.yml
@@ -7,7 +7,7 @@ architecture: linux
 services:
   hugo-container:
     image: klakegg/hugo:0.101.0-alpine
-    cmd: shell
+    commmand: shell
     setup-commands:
       - cp -R /tmp/repo /src
 


### PR DESCRIPTION
For unclear reasons the native compose directive `command` was implemented as `cmd` in the GMT.

This changes to documentation to reflect the newest changes in the main branch.

https://docs.docker.com/compose/compose-file/compose-file-v2/#command